### PR TITLE
add `+nightly` to README instructions

### DIFF
--- a/synthesizer-io-wasm/README.md
+++ b/synthesizer-io-wasm/README.md
@@ -1,7 +1,7 @@
 Generally following [wasm-bindgen tutorial](https://rustwasm.github.io/wasm-bindgen/basic-usage.html).
 
 ```
-cargo build --target=wasm32-unknown-unknown --release
+cargo +nightly build --target=wasm32-unknown-unknown --release
 wasm-bindgen target/wasm32-unknown-unknown/release/synthesizer_io_wasm.wasm --out-dir .
 npm install
 npm run serve


### PR DESCRIPTION
I think this is currently necessary, unless `nightly` is your default toolchain.