### PR TITLE
Fix link pointing to the new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synthesizer IO
 
-Development has moved to [https://github.com/raphlinus/synthesizer-io](raphlinus/synthesizer-io).
+Development has moved to https://github.com/raphlinus/synthesizer-io.
 
 ## Disclaimer
 


### PR DESCRIPTION
Current link is pointing to a subdirectory of this repo (and hence broken).
GitHub auto-links URLs, so we can just leave the URL literal inline as-is.